### PR TITLE
chore: double indentation required for CodeBlock inside ListItem

### DIFF
--- a/lib/parser/index.js
+++ b/lib/parser/index.js
@@ -22,13 +22,19 @@ export class Parser {
 		this.#parsedContent = []
 	}
 
+	static escape(str) {
+		return str.replaceAll(">", "&gt;")
+			.replaceAll("<", "&lt;")
+			.replaceAll("\"", "&quot;")
+			.replaceAll("'", "&#39;")
+	}
+
 	static parseContent(token) {
 		return token.value.replace(REGEX.PARAGRAPH.BOLD, "<strong>$1</strong>")
 			.replace(REGEX.PARAGRAPH.ITALIC,"<em>$1</em>")
 			.replace(REGEX.PARAGRAPH.CODE, (match, value) => {
 				return `<code>${
-					value.replaceAll(">", "&gt;")
-						.replaceAll("<", "&lt;")
+					Parser.escape(value)
 				}</code>`
 			})
 			.replace(REGEX.PARAGRAPH.STRIKE, "<s>$1</s>")

--- a/lib/tokenizer/codeblock.js
+++ b/lib/tokenizer/codeblock.js
@@ -59,6 +59,16 @@ export class CodeBlock {
 		) {
 			return true
 		}
+
+		// under deep condition
+		// cb needs to be indented at least twice
+		if (
+			deep && indent >= 8 &&
+			(!lastLexer || lastLexer?.type === TOKENS.NEW_LINE)
+		) {
+			return true
+		}
+
 		return CodeBlock.testRegex(text)
 	}
 	static tokenize(lines, cursor, indent, rawIndent) {
@@ -104,6 +114,6 @@ export class CodeBlock {
 		} else {
 			skeleton = skeleton.replace("%class", "")
 		}
-		return skeleton.replace("%s", Parser.parseContent(lexer))
+		return skeleton.replace("%s", Parser.escape(lexer.value))
 	}
 }

--- a/lib/tokenizer/list.js
+++ b/lib/tokenizer/list.js
@@ -148,7 +148,7 @@ export class List {
 		lexer.items.forEach(listItem => {
 			let listItemHtml = `
 <li>%s</li>`
-			const pp = new Parser(listItem.tokens)
+			const lParser = new Parser(listItem.tokens)
 			if (lexer.meta.check) {
 				const isChecked = (listItem.checked) ? " checked" : ""
 				listItemHtml = listItemHtml. replace(
@@ -156,7 +156,7 @@ export class List {
 					"<input type='checkbox'" +
 						isChecked +
 						">" +
-						pp.run()
+						lParser.run()
 				)
 			} else {
 				listItemHtml = listItemHtml.replace(

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "jest": "jest --silent ",
     "jest:nocov": "jest --no-coverage",
     "jest:watch": "jest --watch --no-coverage",
+		"jest:lexer:watch": "pnpm jest:watch tests/unit/lexer.spec.js",
+		"jest:parser:watch": "pnpm jest:watch tests/unit/parser.spec.js",
+		"jest:integration:watch": "pnpm jest:watch tests/integration/index.spec.js",
     "lint": "eslint . --ext .js",
     "lint:fix": "pnpm lint --fix"
   },

--- a/tests/integration/__snapshots__/index.spec.js.snap
+++ b/tests/integration/__snapshots__/index.spec.js.snap
@@ -58,9 +58,9 @@ const b = 1;
 const c = a + b;
 
 if (c === 2) {
-  console.log('success');
+  console.log(&#39;success&#39;);
 } else {
-  console.log('failure');
+  console.log(&#39;failure&#39;);
 }</code></pre>
 <p>  some line with small space ahead</p>
 <br>
@@ -146,7 +146,7 @@ exports[`To HTML should parse the markdown file content to html 2`] = `
 </ol>
 <br><p>Here's some example code:</p>
 <br>
-<pre><code>return shell_exec(\\"echo $input | $markdown_script\\");</code></pre>
+<pre><code>return shell_exec(&quot;echo $input | $markdown_script&quot;);</code></pre>
 
 </blockquote>
 <br><p>Any decent text editor should make email-style quoting easy. For example, with BBEdit, you can make a selection and choose Increase Quote Level from the Text menu.</p>
@@ -235,7 +235,9 @@ exports[`To HTML should parse the markdown file content to html 2`] = `
 <br>
 <ul>
 <li><p>  A list item with a code block:</p>
-<br><p>        <code goes here></p></li>
+<br>
+<pre><code>&lt;code goes here&gt;</code></pre>
+</li>
 </ul>
 <br>
 <h3>Code Blocks</h3>
@@ -247,20 +249,20 @@ exports[`To HTML should parse the markdown file content to html 2`] = `
 
 <br><p>Here is an example of AppleScript:</p>
 <br>
-<pre><code>tell application \\"Foo\\"
+<pre><code>tell application &quot;Foo&quot;
     beep
 end tell</code></pre>
 
 <br><p>A code block continues until it reaches a line that is not indented (or the end of the article).</p>
 <br><p>Within a code block, ampersands (<code>&</code>) and angle brackets (<code>&lt;</code> and <code>&gt;</code>) are automatically converted into HTML entities. This makes it very easy to include example HTML source code using Markdown -- just paste it and indent it, and Markdown will handle the hassle of encoding the ampersands and angle brackets. For example, this:</p>
 <br>
-<pre><code><div class=\\"footer\\">
+<pre><code>&lt;div class=&quot;footer&quot;&gt;
     &copy; 2004 Foo Corporation
-</div></code></pre>
+&lt;/div&gt;</code></pre>
 
 <br><p>Regular Markdown syntax is not processed within code blocks. E.g., asterisks are just literal asterisks within a code block. This means it's also easy to use Markdown to write about Markdown's own syntax.</p>
 <br>
-<pre><code>tell application \\"Foo\\"
+<pre><code>tell application &quot;Foo&quot;
     beep
 end tell</code></pre>
 
@@ -339,7 +341,7 @@ end tell</code></pre>
 </ol>
 <br><p>Here's some example code:</p>
 <br>
-<pre><code>return shell_exec(\\"echo $input | $markdown_script\\");</code></pre>
+<pre><code>return shell_exec(&quot;echo $input | $markdown_script&quot;);</code></pre>
 
 </blockquote>
 <br><p>Any decent text editor should make email-style quoting easy. For example, with BBEdit, you can make a selection and choose Increase Quote Level from the Text menu.</p>
@@ -428,7 +430,9 @@ end tell</code></pre>
 <br>
 <ul>
 <li><p>  A list item with a code block:</p>
-<br><p>        <code goes here></p></li>
+<br>
+<pre><code>&lt;code goes here&gt;</code></pre>
+</li>
 </ul>
 <br>
 <h3>Code Blocks</h3>
@@ -440,20 +444,20 @@ end tell</code></pre>
 
 <br><p>Here is an example of AppleScript:</p>
 <br>
-<pre><code>tell application \\"Foo\\"
+<pre><code>tell application &quot;Foo&quot;
     beep
 end tell</code></pre>
 
 <br><p>A code block continues until it reaches a line that is not indented (or the end of the article).</p>
 <br><p>Within a code block, ampersands (<code>&</code>) and angle brackets (<code>&lt;</code> and <code>&gt;</code>) are automatically converted into HTML entities. This makes it very easy to include example HTML source code using Markdown -- just paste it and indent it, and Markdown will handle the hassle of encoding the ampersands and angle brackets. For example, this:</p>
 <br>
-<pre><code><div class=\\"footer\\">
+<pre><code>&lt;div class=&quot;footer&quot;&gt;
     &copy; 2004 Foo Corporation
-</div></code></pre>
+&lt;/div&gt;</code></pre>
 
 <br><p>Regular Markdown syntax is not processed within code blocks. E.g., asterisks are just literal asterisks within a code block. This means it's also easy to use Markdown to write about Markdown's own syntax.</p>
 <br>
-<pre><code>tell application \\"Foo\\"
+<pre><code>tell application &quot;Foo&quot;
     beep
 end tell</code></pre>
 
@@ -532,7 +536,7 @@ end tell</code></pre>
 </ol>
 <br><p>Here's some example code:</p>
 <br>
-<pre><code>return shell_exec(\\"echo $input | $markdown_script\\");</code></pre>
+<pre><code>return shell_exec(&quot;echo $input | $markdown_script&quot;);</code></pre>
 
 </blockquote>
 <br><p>Any decent text editor should make email-style quoting easy. For example, with BBEdit, you can make a selection and choose Increase Quote Level from the Text menu.</p>
@@ -621,7 +625,9 @@ end tell</code></pre>
 <br>
 <ul>
 <li><p>  A list item with a code block:</p>
-<br><p>        <code goes here></p></li>
+<br>
+<pre><code>&lt;code goes here&gt;</code></pre>
+</li>
 </ul>
 <br>
 <h3>Code Blocks</h3>
@@ -633,20 +639,20 @@ end tell</code></pre>
 
 <br><p>Here is an example of AppleScript:</p>
 <br>
-<pre><code>tell application \\"Foo\\"
+<pre><code>tell application &quot;Foo&quot;
     beep
 end tell</code></pre>
 
 <br><p>A code block continues until it reaches a line that is not indented (or the end of the article).</p>
 <br><p>Within a code block, ampersands (<code>&</code>) and angle brackets (<code>&lt;</code> and <code>&gt;</code>) are automatically converted into HTML entities. This makes it very easy to include example HTML source code using Markdown -- just paste it and indent it, and Markdown will handle the hassle of encoding the ampersands and angle brackets. For example, this:</p>
 <br>
-<pre><code><div class=\\"footer\\">
+<pre><code>&lt;div class=&quot;footer&quot;&gt;
     &copy; 2004 Foo Corporation
-</div></code></pre>
+&lt;/div&gt;</code></pre>
 
 <br><p>Regular Markdown syntax is not processed within code blocks. E.g., asterisks are just literal asterisks within a code block. This means it's also easy to use Markdown to write about Markdown's own syntax.</p>
 <br>
-<pre><code>tell application \\"Foo\\"
+<pre><code>tell application &quot;Foo&quot;
     beep
 end tell</code></pre>
 
@@ -725,7 +731,7 @@ end tell</code></pre>
 </ol>
 <br><p>Here's some example code:</p>
 <br>
-<pre><code>return shell_exec(\\"echo $input | $markdown_script\\");</code></pre>
+<pre><code>return shell_exec(&quot;echo $input | $markdown_script&quot;);</code></pre>
 
 </blockquote>
 <br><p>Any decent text editor should make email-style quoting easy. For example, with BBEdit, you can make a selection and choose Increase Quote Level from the Text menu.</p>
@@ -814,7 +820,9 @@ end tell</code></pre>
 <br>
 <ul>
 <li><p>  A list item with a code block:</p>
-<br><p>        <code goes here></p></li>
+<br>
+<pre><code>&lt;code goes here&gt;</code></pre>
+</li>
 </ul>
 <br>
 <h3>Code Blocks</h3>
@@ -826,20 +834,20 @@ end tell</code></pre>
 
 <br><p>Here is an example of AppleScript:</p>
 <br>
-<pre><code>tell application \\"Foo\\"
+<pre><code>tell application &quot;Foo&quot;
     beep
 end tell</code></pre>
 
 <br><p>A code block continues until it reaches a line that is not indented (or the end of the article).</p>
 <br><p>Within a code block, ampersands (<code>&</code>) and angle brackets (<code>&lt;</code> and <code>&gt;</code>) are automatically converted into HTML entities. This makes it very easy to include example HTML source code using Markdown -- just paste it and indent it, and Markdown will handle the hassle of encoding the ampersands and angle brackets. For example, this:</p>
 <br>
-<pre><code><div class=\\"footer\\">
+<pre><code>&lt;div class=&quot;footer&quot;&gt;
     &copy; 2004 Foo Corporation
-</div></code></pre>
+&lt;/div&gt;</code></pre>
 
 <br><p>Regular Markdown syntax is not processed within code blocks. E.g., asterisks are just literal asterisks within a code block. This means it's also easy to use Markdown to write about Markdown's own syntax.</p>
 <br>
-<pre><code>tell application \\"Foo\\"
+<pre><code>tell application &quot;Foo&quot;
     beep
 end tell</code></pre>
 
@@ -916,7 +924,7 @@ end tell</code></pre>
 </ol>
 <br><p>Here's some example code:</p>
 <br>
-<pre><code>return shell_exec(\\"echo $input | $markdown_script\\");</code></pre>
+<pre><code>return shell_exec(&quot;echo $input | $markdown_script&quot;);</code></pre>
 
 </blockquote>
 <br><p>Any decent text editor should make email-style quoting easy. For example, with BBEdit, you can make a selection and choose Increase Quote Level from the Text menu.</p>
@@ -1005,7 +1013,9 @@ end tell</code></pre>
 <br>
 <ul>
 <li><p>  A list item with a code block:</p>
-<br><p>        <code goes here></p></li>
+<br>
+<pre><code>&lt;code goes here&gt;</code></pre>
+</li>
 </ul>
 <br>
 <h3>Code Blocks</h3>
@@ -1017,20 +1027,20 @@ end tell</code></pre>
 
 <br><p>Here is an example of AppleScript:</p>
 <br>
-<pre><code>tell application \\"Foo\\"
+<pre><code>tell application &quot;Foo&quot;
     beep
 end tell</code></pre>
 
 <br><p>A code block continues until it reaches a line that is not indented (or the end of the article).</p>
 <br><p>Within a code block, ampersands (<code>&</code>) and angle brackets (<code>&lt;</code> and <code>&gt;</code>) are automatically converted into HTML entities. This makes it very easy to include example HTML source code using Markdown -- just paste it and indent it, and Markdown will handle the hassle of encoding the ampersands and angle brackets. For example, this:</p>
 <br>
-<pre><code><div class=\\"footer\\">
+<pre><code>&lt;div class=&quot;footer&quot;&gt;
     &copy; 2004 Foo Corporation
-</div></code></pre>
+&lt;/div&gt;</code></pre>
 
 <br><p>Regular Markdown syntax is not processed within code blocks. E.g., asterisks are just literal asterisks within a code block. This means it's also easy to use Markdown to write about Markdown's own syntax.</p>
 <br>
-<pre><code>tell application \\"Foo\\"
+<pre><code>tell application &quot;Foo&quot;
     beep
 end tell</code></pre>
 
@@ -1107,7 +1117,7 @@ end tell</code></pre>
 </ol>
 <br><p>Here's some example code:</p>
 <br>
-<pre><code>return shell_exec(\\"echo $input | $markdown_script\\");</code></pre>
+<pre><code>return shell_exec(&quot;echo $input | $markdown_script&quot;);</code></pre>
 
 </blockquote>
 <br><p>Any decent text editor should make email-style quoting easy. For example, with BBEdit, you can make a selection and choose Increase Quote Level from the Text menu.</p>
@@ -1196,7 +1206,9 @@ end tell</code></pre>
 <br>
 <ul>
 <li><p>  A list item with a code block:</p>
-<br><p>        <code goes here></p></li>
+<br>
+<pre><code>&lt;code goes here&gt;</code></pre>
+</li>
 </ul>
 <br>
 <h3>Code Blocks</h3>
@@ -1208,20 +1220,20 @@ end tell</code></pre>
 
 <br><p>Here is an example of AppleScript:</p>
 <br>
-<pre><code>tell application \\"Foo\\"
+<pre><code>tell application &quot;Foo&quot;
     beep
 end tell</code></pre>
 
 <br><p>A code block continues until it reaches a line that is not indented (or the end of the article).</p>
 <br><p>Within a code block, ampersands (<code>&</code>) and angle brackets (<code>&lt;</code> and <code>&gt;</code>) are automatically converted into HTML entities. This makes it very easy to include example HTML source code using Markdown -- just paste it and indent it, and Markdown will handle the hassle of encoding the ampersands and angle brackets. For example, this:</p>
 <br>
-<pre><code><div class=\\"footer\\">
+<pre><code>&lt;div class=&quot;footer&quot;&gt;
     &copy; 2004 Foo Corporation
-</div></code></pre>
+&lt;/div&gt;</code></pre>
 
 <br><p>Regular Markdown syntax is not processed within code blocks. E.g., asterisks are just literal asterisks within a code block. This means it's also easy to use Markdown to write about Markdown's own syntax.</p>
 <br>
-<pre><code>tell application \\"Foo\\"
+<pre><code>tell application &quot;Foo&quot;
     beep
 end tell</code></pre>
 

--- a/tests/unit/__snapshots__/lexer.spec.js.snap
+++ b/tests/unit/__snapshots__/lexer.spec.js.snap
@@ -471,6 +471,62 @@ Array [
 ]
 `;
 
+exports[`lexer list Should allow indented codeblock inside 1`] = `
+Array [
+  Object {
+    "indent": 0,
+    "raw": "To put a code block within a list item, the code block needs
+to be indented *twice* -- 8 spaces or two tabs:",
+    "type": "paragraph",
+    "value": "To put a code block within a list item, the code block needs to be indented *twice* -- 8 spaces or two tabs:",
+  },
+  Object {
+    "indent": 0,
+    "items": Array [
+      Object {
+        "checked": null,
+        "count": null,
+        "tokens": Array [
+          Object {
+            "indent": 0,
+            "raw": "  A list item with a code block:",
+            "type": "paragraph",
+            "value": "  A list item with a code block:",
+          },
+          Object {
+            "type": "new-line",
+          },
+          Object {
+            "indent": 8,
+            "language": null,
+            "raw": "        <code goes here>",
+            "type": "code-block",
+            "value": "<code goes here>",
+          },
+        ],
+        "type": "list-item",
+      },
+    ],
+    "meta": Object {
+      "check": false,
+      "identifier": "*",
+      "ordered": false,
+    },
+    "type": "list",
+  },
+  Object {
+    "type": "new-line",
+  },
+  Object {
+    "indent": 0,
+    "level": 3,
+    "raw": "### Code Blocks",
+    "type": "heading",
+    "value": "Code Blocks",
+  },
+]
+`;
+
 exports[`lexer list less than 4 indent should not break the list 1`] = `
 Array [
   Object {

--- a/tests/unit/__snapshots__/parser.spec.js.snap
+++ b/tests/unit/__snapshots__/parser.spec.js.snap
@@ -23,7 +23,7 @@ exports[`Parser codeblock should parse indent codeblock 1`] = `
 
 <br><p>Here is an example of AppleScript:</p>
 <br>
-<pre><code>tell application \\"Foo\\"
+<pre><code>tell application &quot;Foo&quot;
 beep
 end tell</code></pre>
 
@@ -200,6 +200,20 @@ exports[`Parser list should detect list indent 1`] = `
 </ul>"
 `;
 
+exports[`Parser list should parse the indented codeblock inside 1`] = `
+"<p>To put a code block within a list item, the code block needs to be indented <em>twice</em> -- 8 spaces or two tabs:</p>
+<ul>
+<li><p>  A list item with a code block:</p>
+<br>
+<pre><code>&lt;code goes here&gt;
+&lt;code goes here&gt;
+&lt;code goes here&gt;</code></pre>
+</li>
+</ul>
+<br>
+<h3>Code Blocks</h3>"
+`;
+
 exports[`Parser list should tokenize a valid ordered list 1`] = `
 "
 <ol>
@@ -336,7 +350,7 @@ exports[`Parser quote should find the list and codeblock inside 1`] = `
 </ol>
 <br><p>Here's some example code:</p>
 <br>
-<pre><code>return shell_exec(\\"echo $input | $markdown_script\\");</code></pre>
+<pre><code>return shell_exec(&quot;echo $input | $markdown_script&quot;);</code></pre>
 
 </blockquote>"
 `;

--- a/tests/unit/lexer.spec.js
+++ b/tests/unit/lexer.spec.js
@@ -462,6 +462,20 @@ describe("lexer", () => {
 			const tokens = lexer.run()
 			expect(tokens).toMatchSnapshot()
 		})
+		it("Should allow indented codeblock inside", () => {
+			const lines = [
+				"To put a code block within a list item, the code block needs",
+				"to be indented *twice* -- 8 spaces or two tabs:",
+				"*   A list item with a code block:",
+				"",
+				"        <code goes here>",
+				"",
+				"### Code Blocks"
+			]
+			const lexer = new Lexer(lines)
+			const tokens = lexer.run()
+			expect(tokens).toMatchSnapshot()
+		})
 	})
 	describe("hr line", () => {
 		it("should parse the hr line", () => {

--- a/tests/unit/parser.spec.js
+++ b/tests/unit/parser.spec.js
@@ -276,6 +276,21 @@ describe("Parser", () => {
 			const html = toHtml(lines)
 			expect(html).toMatchSnapshot()
 		})
+		it("should parse the indented codeblock inside", () => {
+			const lines = [
+				"To put a code block within a list item, the code block needs",
+				"to be indented *twice* -- 8 spaces or two tabs:",
+				"*   A list item with a code block:",
+				"",
+				"        <code goes here>",
+				"        <code goes here>",
+				"        <code goes here>",
+				"",
+				"### Code Blocks"
+			]
+			const html = toHtml(lines)
+			expect(html).toMatchSnapshot()
+		})
 	})
 	describe("hr line", () => {
 		it.each([


### PR DESCRIPTION
- Double indentation for CodeBlock inside ListItem body
- Update tests and snapshots